### PR TITLE
ci: fix pull request workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,30 @@
+name: Setup
+description: Setup the environment
+
+inputs:
+  node-version:
+    description: The version of node.js
+    required: false
+    default: "20"
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4.0.0
+      with:
+        run_install: false
+
+    - name: Setup node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        registry-url: "https://registry.npmjs.org"
+
+    - name: Install
+      run: pnpm install
+      shell: bash
+
+    - name: Build packages
+      run: pnpm build
+      shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: The version of node.js
     required: false
-    default: "20"
+    default: '20'
 
 runs:
   using: composite
@@ -19,7 +19,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
-        registry-url: "https://registry.npmjs.org"
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install
       run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: main
+    branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
 env:
   CI: true
@@ -19,7 +19,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.11.0
+          node-version: 20.18.1
 
       - uses: pnpm/action-setup@v4.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Install cypress
+        run: pnpm exec cypress install
+
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,52 +6,25 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  CI: true
 jobs:
-  release:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: setup node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.18.1
+      - uses: ./.github/actions/setup
 
-      - uses: pnpm/action-setup@v4.0.0
-        with:
-          run_install: false
+      - name: Lint
+        run: pnpm run lint
 
-      - name: get pnpm store directory
-        id: pnpm-cache
-        run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: load cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/Cypress
-            ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-
-      - name: install dependencies
-        run: pnpm install
-
-      - name: build packs
-        run: pnpm build
-
-      - name: run lint test
-        run: pnpm lint
-
-      - name: setup firefox
+      - name: Setup firefox
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: latest-esr
 
-      - name: run e2e test on chrome
+      - name: Run e2e test on chrome
         uses: cypress-io/github-action@v6
         env:
           CYPRESS_SERVER_PORT: 7000
@@ -60,10 +33,10 @@ jobs:
           install: false
           working-directory: e2e
           start: pnpm exec vite preview --port 7000 --host
-          wait-on: 'http://localhost:7000'
+          wait-on: "http://localhost:7000"
           browser: chrome
 
-      - name: run e2e test on firefox
+      - name: Run e2e test on firefox
         uses: cypress-io/github-action@v6
         env:
           CYPRESS_SERVER_PORT: 7001
@@ -72,30 +45,5 @@ jobs:
           install: false
           working-directory: e2e
           start: pnpm exec vite preview --port 7001 --host
-          wait-on: 'http://localhost:7001'
+          wait-on: "http://localhost:7001"
           browser: firefox
-
-      - name: create versions or publish to npm registry
-        uses: changesets/action@v1
-        with:
-          publish: pnpm release
-          commit: 'ci(changeset): release prosemirror-adapter'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: export screenshots (on failure only)
-        uses: actions/upload-artifact@v4.4.3
-        if: ${{ failure() }}
-        with:
-          name: cypress-screenshots
-          path: e2e/cypress/screenshots
-          retention-days: 7
-
-      - name: export screen recordings (on failure only)
-        uses: actions/upload-artifact@v4.4.3
-        if: ${{ failure() }}
-        with:
-          name: cypress-videos
-          path: e2e/cypress/videos
-          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           install: false
           working-directory: e2e
           start: pnpm exec vite preview --port 7000 --host
-          wait-on: "http://localhost:7000"
+          wait-on: 'http://localhost:7000'
           browser: chrome
 
       - name: Run e2e test on firefox
@@ -45,5 +45,5 @@ jobs:
           install: false
           working-directory: e2e
           start: pnpm exec vite preview --port 7001 --host
-          wait-on: "http://localhost:7001"
+          wait-on: 'http://localhost:7001'
           browser: firefox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: pnpm run lint
 
       - name: Install cypress
-        run: pnpm exec cypress install
+        run: pnpm run install:cypress
 
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: create versions or publish to npm registry
+      - name: Create versions or publish to npm registry
         uses: changesets/action@v1
         with:
           publish: pnpm release
@@ -23,7 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: export screenshots (on failure only)
+      - name: Export screenshots (on failure only)
         uses: actions/upload-artifact@v4.4.3
         if: ${{ failure() }}
         with:
@@ -31,7 +31,7 @@ jobs:
           path: e2e/cypress/screenshots
           retention-days: 7
 
-      - name: export screen recordings (on failure only)
+      - name: Export screen recordings (on failure only)
         uses: actions/upload-artifact@v4.4.3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm release
-          commit: "ci(changeset): release prosemirror-adapter"
+          commit: 'ci(changeset): release prosemirror-adapter'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: create versions or publish to npm registry
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          commit: "ci(changeset): release prosemirror-adapter"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: export screenshots (on failure only)
+        uses: actions/upload-artifact@v4.4.3
+        if: ${{ failure() }}
+        with:
+          name: cypress-screenshots
+          path: e2e/cypress/screenshots
+          retention-days: 7
+
+      - name: export screen recordings (on failure only)
+        uses: actions/upload-artifact@v4.4.3
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: e2e/cypress/videos
+          retention-days: 7

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,7 +10,8 @@
     "test": "cross-env CYPRESS_SERVER_PORT=7001 cypress run",
     "test:verbose": "cross-env CYPRESS_SERVER_PORT=7001 cypress open",
     "start:test": "cross-env CYPRESS_SERVER_PORT=7001 start-test setup :7001 test",
-    "start:test:verbose": "cross-env CYPRESS_SERVER_PORT=7001 start-test start :7001 test:verbose"
+    "start:test:verbose": "cross-env CYPRESS_SERVER_PORT=7001 start-test start :7001 test:verbose",
+    "install:cypress": "cypress install"
   },
   "devDependencies": {
     "@lit-labs/context": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "changeset": "changeset",
     "lint": "eslint .",
     "release": "changeset publish",
-    "prepare": "husky"
+    "prepare": "husky",
+    "install:cypress": "pnpm --filter=e2e install:cypress"
   },
   "dependencies": {
     "@antfu/eslint-config": "^3.0.0",


### PR DESCRIPTION
1. Put the changeset-related CI steps in a separate workflow file `.github/workflows/release.yml` and only trigger this workflow on `main` branch push event. This ensure that pull requests from forks won't trigger this workflow and won't fail because of missing tokens. 
2. Put shared CI steps into `.github/actions/setup/action.yml` and reuse it in different workflows. 
