### PR TITLE
ci: test example building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ docs
 coverage
 test-results
 .pnpm-store
-.npmrc
 tsconfig.tsbuildinfo
 e2e/cypress/videos
 e2e/cypress/screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ docs
 coverage
 test-results
 .pnpm-store
+.npmrc
 tsconfig.tsbuildinfo
 e2e/cypress/videos
 e2e/cypress/screenshots

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+link-workspace-packages=deep

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-link-workspace-packages=deep

--- a/examples/lit/package.json
+++ b/examples/lit/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "start": "vite"
+    "start": "vite",
+    "build": "vite build"
   },
   "dependencies": {
     "@lit-labs/context": "^0.5.1",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "start": "vite"
+    "start": "vite",
+    "build": "vite build"
   },
   "dependencies": {
     "@prosemirror-adapter/react": "*",

--- a/examples/solid/package.json
+++ b/examples/solid/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "start": "vite",
-    "dev": "vite"
+    "dev": "vite",
+    "build": "vite build"
   },
   "dependencies": {
     "@prosemirror-adapter/solid": "*",

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "start": "vite"
+    "start": "vite",
+    "build": "vite build"
   },
   "dependencies": {
     "@prosemirror-adapter/svelte": "*",
@@ -18,6 +19,7 @@
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.3.1",
     "@sveltejs/kit": "^2.12.2",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "prettier": "^3.4.2",
     "prettier-plugin-svelte": "^3.3.2",
     "svelte": "^5.14.4",

--- a/examples/svelte/svelte.config.js
+++ b/examples/svelte/svelte.config.js
@@ -1,16 +1,16 @@
 import adapter from '@sveltejs/adapter-auto'
-import { vitePreprocess } from '@sveltejs/kit/vite'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  // Consult https://kit.svelte.dev/docs/integrations#preprocessors
+  // Consult https://svelte.dev/docs/kit/integrations
   // for more information about preprocessors
   preprocess: vitePreprocess(),
 
   kit: {
-    // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-    // If your environment is not supported or you settled on a specific environment, switch out the adapter.
-    // See https://kit.svelte.dev/docs/adapters for more information about adapters.
+    // adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
+    // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
+    // See https://svelte.dev/docs/kit/adapters for more information about adapters.
     adapter: adapter(),
   },
 }

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "start": "vite"
+    "start": "vite",
+    "build": "vite build"
   },
   "dependencies": {
     "@prosemirror-adapter/vue": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       '@sveltejs/kit':
         specifier: ^2.12.2
         version: 2.12.2(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.14.4)(vite@5.4.11(@types/node@22.10.1)))(svelte@5.14.4)(vite@5.4.11(@types/node@22.10.1))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^4.0.0
+        version: 4.0.4(svelte@5.14.4)(vite@5.4.11(@types/node@22.10.1))
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -1162,9 +1165,6 @@ packages:
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
-
-  '@prosemirror-adapter/core@0.4.0':
-    resolution: {integrity: sha512-feLFTIvbpQDnWspZv+rjTPmqpeJ8++VM/gDnBaDNLsAEvrwmO1IHc0oyrRBl/9x3Er3tU/WXc86TlOidsN1aEg==}
 
   '@prosemirror-adapter/lit@0.4.0':
     resolution: {integrity: sha512-QN+elebcgFXLgPepdo5sHF/C5owVCTeXkS7i80JeSUzKB6Txxm5tI2bDg0mRYCAMKzpTIl5Og4EARmJX7hSCVg==}
@@ -4830,21 +4830,17 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
-  '@prosemirror-adapter/core@0.4.0':
-    dependencies:
-      tslib: 2.8.1
-
   '@prosemirror-adapter/lit@0.4.0(@lit-labs/context@0.5.1)(lit@2.8.0)':
     dependencies:
       '@lit-labs/context': 0.5.1
-      '@prosemirror-adapter/core': 0.4.0
+      '@prosemirror-adapter/core': link:packages/core
       lit: 2.8.0
       nanoid: 5.0.9
       tslib: 2.8.1
 
   '@prosemirror-adapter/react@0.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@prosemirror-adapter/core': 0.4.0
+      '@prosemirror-adapter/core': link:packages/core
       nanoid: 5.0.9
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -4852,21 +4848,21 @@ snapshots:
 
   '@prosemirror-adapter/solid@0.4.0(solid-js@1.9.3)':
     dependencies:
-      '@prosemirror-adapter/core': 0.4.0
+      '@prosemirror-adapter/core': link:packages/core
       nanoid: 5.0.9
       solid-js: 1.9.3
       tslib: 2.8.1
 
   '@prosemirror-adapter/svelte@0.4.0(svelte@5.14.4)':
     dependencies:
-      '@prosemirror-adapter/core': 0.4.0
+      '@prosemirror-adapter/core': link:packages/core
       nanoid: 5.0.9
       svelte: 5.14.4
       tslib: 2.8.1
 
   '@prosemirror-adapter/vue@0.4.0(vue@3.5.13(typescript@5.6.3))':
     dependencies:
-      '@prosemirror-adapter/core': 0.4.0
+      '@prosemirror-adapter/core': link:packages/core
       nanoid: 5.0.9
       tslib: 2.8.1
       vue: 3.5.13(typescript@5.6.3)


### PR DESCRIPTION
Run the `build` script for all examples during CI pipeline. The `build` script for the `examples/svelte` has been broken for a while. This PR can prevent it from happening again.