### PR TITLE
chore: adjust renovate config to make it easier to bump dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,23 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
-  "extends": ["github>ocavue/config-renovate"]
+  "extends": ["github>ocavue/config-renovate"],
+  "packageRules": [
+    {
+      "matchDepNames": ["svelte", "/@sveltejs/"],
+      "groupName": "svelte"
+    },
+    {
+      "matchDepNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+      "groupName": "react"
+    },
+    {
+      "matchDepNames": ["vue", "/@vue/"],
+      "groupName": "vue"
+    },
+    {
+      "matchDepNames": ["vite", "/@vitejs/"],
+      "groupName": "vite"
+    }
+  ]
 }

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 pnpm exec commitlint --edit $1


### PR DESCRIPTION
# Summary

  This PR enhances the Renovate dependency management configuration and resolves a Husky warning by simplifying the commit message hook.

# Changes

  - Renovate Configuration: Added package grouping rules to organize dependency updates by framework/tool:
    - Group Svelte-related packages together
    - Group React-related packages together
    - Group Vue-related packages together
    - Group Vite-related packages together
  - Husky Fix: Simplified the commit-msg hook to remove unnecessary boilerplate and fix warning

# Benefits

  - Reduces PR noise by grouping related dependency updates
  - Makes dependency management more organized and easier to review
  - Eliminates Husky warning messages
  - Cleaner commit message validation setup