### PR TITLE
fix(core): reduce node view destroy calls

### DIFF
--- a/.changeset/warm-poets-look.md
+++ b/.changeset/warm-poets-look.md
@@ -1,0 +1,5 @@
+---
+'@prosemirror-adapter/core': patch
+---
+
+Don't destory the node view when the associated node's decorations are updated.

--- a/packages/core/src/nodeView/CoreNodeView.ts
+++ b/packages/core/src/nodeView/CoreNodeView.ts
@@ -80,10 +80,7 @@ export class CoreNodeView<ComponentType> implements NodeView {
     decorations,
     innerDecorations,
   ) => {
-    const userUpdate = this.options.update
-    let result = userUpdate?.(node, decorations, innerDecorations)
-
-    if (typeof result !== 'boolean') result = this.shouldUpdate(node)
+    const result = this.options.update?.(node, decorations, innerDecorations) ?? this.shouldUpdate(node)
 
     this.node = node
     this.decorations = decorations

--- a/packages/core/src/nodeView/CoreNodeView.ts
+++ b/packages/core/src/nodeView/CoreNodeView.ts
@@ -69,12 +69,10 @@ export class CoreNodeView<ComponentType> implements NodeView {
     this.options.deselectNode?.()
   }
 
+  // Return true if the current node view instance can handle the update.
+  // Return false if a new node view instance should be created.
   shouldUpdate: (node: Node) => boolean = (node) => {
-    if (node.type !== this.node.type) return false
-
-    if (node.sameMarkup(this.node) && node.content.eq(this.node.content)) return false
-
-    return true
+    return node.type === this.node.type
   }
 
   update: (node: Node, decorations: readonly Decoration[], innerDecorations: DecorationSource) => boolean = (
@@ -83,8 +81,7 @@ export class CoreNodeView<ComponentType> implements NodeView {
     innerDecorations,
   ) => {
     const userUpdate = this.options.update
-    let result
-    if (userUpdate) result = userUpdate(node, decorations, innerDecorations)
+    let result = userUpdate?.(node, decorations, innerDecorations)
 
     if (typeof result !== 'boolean') result = this.shouldUpdate(node)
 


### PR DESCRIPTION
During the addition of Preact support, I found that the node view gets destroyed and re-created when a widget decoration is created around this node. This recreation of the node view breaks the text selection, as shown in the video below:

https://github.com/user-attachments/assets/2f484817-ae07-4520-97c8-fadb201d5e18

This PR removes the node view recreation in these cases. All tests have passed, so I think it's fine to make the change.